### PR TITLE
Fix dead neptune.ai citation link in knowledge distillation notebook

### DIFF
--- a/model_deployment/transformers/response_knowledge_distillation.ipynb
+++ b/model_deployment/transformers/response_knowledge_distillation.ipynb
@@ -1585,7 +1585,7 @@
    "source": [
     "- [[1]](https://www.philschmid.de/knowledge-distillation-bert-transformers) Blog: Task-specific knowledge distillation for BERT using Transformers & Amazon SageMaker\n",
     "- [[2]](https://medium.com/huggingface/distilbert-8cf3380435b5) Blog: Smaller, faster, cheaper, lighter: Introducing DistilBERT, a distilled version of BERT\n",
-    "- [[3]](https://neptune.ai/blog/knowledge-distillation) Blog: Knowledge Distillation: Principles, Algorithms, Applications\n",
+    "- [[3]](https://web.archive.org/web/20251006155819/https://neptune.ai/blog/knowledge-distillation) Blog: Knowledge Distillation: Principles, Algorithms, Applications\n",
     "- [[4]](https://lewtun.github.io/blog/weeknotes/nlp/huggingface/transformers/2021/01/17/wknotes-distillation-and-generation.html) Blog: Weeknotes: Distilling distilled transformers\n",
     "- [[5]](https://intellabs.github.io/distiller/knowledge_distillation.html) Doc: Neural Network Distiller - Knowledge Distillation\n",
     "- [[6]](https://arxiv.org/abs/1503.02531) Paper: Geoffrey Hinton, Oriol Vinyals, et al. - Distilling the Knowledge in a Neural Network - 2015\n",


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now redirects to the acquisition announcement, so the neptune.ai/blog links in this repo no longer lead to the referenced articles.

Reference [3] in `response_knowledge_distillation.ipynb` cites Neptune's *Knowledge Distillation: Principles, Algorithms, Applications*. This PR points the citation to the Wayback Machine snapshot of the original article (last capture before the redirect), preserving the reference as cited.